### PR TITLE
S31emulationstation, enable safe shutdown for metadata

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/batocera/fsoverlay/etc/init.d/S31emulationstation
@@ -11,8 +11,12 @@ case "$1" in
                 HOME=/userdata/system LANG="${settings_lang}.UTF-8" SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so SDL_VIDEO_EGL_DRIVER=/usr/lib/libGLESv2.so SDL_NOMOUSE=1 /usr/bin/emulationstation --no-splash &
 	fi
 	;;
-  stop)
-	killall emulationstation
+  stop) # Safe Shutdown for securing metadata
+        PID=$(pidof emulationstation)
+        kill $PID
+        while [ -e /proc/$PID ]; do
+            sleep 0.25
+        done
 	;;
   restart|reload)
         "$0" stop


### PR DESCRIPTION
This will enable safe shutdown to write metadata (XML files) to disk
A fast shutdown will not be affected, that means fast shutdown does not write data
A "normal" shutdown will work and write metadata to disk (favourites, scraped data, access time....)
This is also usefull if a shutdown is initiated by a power switch.