### PR TITLE
add: daemon-service for all splash services

### DIFF
--- a/package/batocera/core/batocera-splash/Ssplash-ffplay
+++ b/package/batocera/core/batocera-splash/Ssplash-ffplay
@@ -1,55 +1,79 @@
 #!/bin/bash
 
-soundDisabled() {
+DAEMON="splash-ffplay"
+DEFAULT="/usr/share/batocera/splash/splash.mp4"
+SPLASH_DIR=/userdata/splash
+
+FM_IMAGE=".*\.\(jpg\|jpeg\|png\)"
+FM_VIDEO=".*\.\(mp4\|MP4\)"
+
+. /etc/profile.d/xdg.sh
+. /etc/profile.d/dbus.sh
+
+soundDisabled()
+{
     grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
 }
 
-do_start ()
+do_filerandomize ()
 {
-    if ls /boot/splash/*.mp4 >/dev/null 2>/dev/null
-    then
-        do_videostart "$(ls /boot/splash/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.mp4 | wc -l)+1))!d")"
-    elif [[ $(ls /boot/splash/*.{jpg,png}  2>/dev/null) ]]
-    then
-        do_imagestart "$(ls /boot/splash/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.{jpg,png} | wc -l)+1))!d")"
+    local array
+    [[ -d "$SPLASH_DIR" ]] || return 1
+    readarray -t array < <(find "$SPLASH_DIR" -regex "$1" -maxdepth 1 -type f)
+    if [[ ${#array[@]} -gt 0 ]]; then
+        echo "${array[$RANDOM % ${#array[@]}]}"
+    fi
+}
+
+do_start()
+{
+    video_file=$(do_filerandomize "$FM_VIDEO")
+    image_file=$(do_filerandomize "$FM_IMAGE")
+
+    if [[ -n "$video_file" ]]; then
+        do_videostart "$video_file"
+    elif [[ -n "$image_file" ]]; then
+        do_imagestart "$image_file"
     else
-        do_videostart "/usr/share/batocera/splash/splash.mp4"
+        do_videostart "$DEFAULT"
     fi
 }
 
 do_imagestart()
 {
     image="$1"
-    # on some sytems, fb0 is not immediatly loaded, so, keep a chance by waiting a bit
-    N=0
-    while ! test -e /dev/fb0 -o $N -gt 15
-    do
-        sleep 1
-        let N++
-    done
-    test -e /dev/fb0 && fbv -f -i "${image}"
-    sleep infinity
-    wait $!
+    printf 'Image: %s: ' "$image"
+    if test -e /dev/fb0
+    then
+        start-stop-daemon -S -b -q -m -p /var/run/user-splash-image.pid --exec fbv -- -f -i "$image"
+    fi
 }
 
 do_videostart ()
 {
     video="$1"
+    printf 'Video: %s: ' "$video"
     ffplay_opt=
     if soundDisabled
     then
         ffplay_opt=-an
     fi
-    /usr/bin/ffplay $ffplay_opt -sync video -autoexit -vcodec h264_v4l2m2m -i "$video" &
-    wait $! 
+    start-stop-daemon -S -b -q -m -p /var/run/user-splash.pid --exec /usr/bin/ffplay -- $ffplay_opt -sync video -autoexit -vcodec h264_v4l2m2m -i "$video"
 }
 
 case "$1" in
     start)
-        grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf" && exit 0
-        do_start &
+        printf 'Starting %s: ' "$DAEMON"
+        if grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf"
+        then
+            echo "SKIPPED"
+            exit 0
+        fi
+        do_start
+        echo "OK"
         ;;
     stop)
+        start-stop-daemon -K -q -p /var/run/user-splash.pid
         ;;
     restart|reload)
         ;;

--- a/package/batocera/core/batocera-splash/Ssplash-image
+++ b/package/batocera/core/batocera-splash/Ssplash-image
@@ -1,37 +1,61 @@
 #!/bin/bash
 
+DAEMON="splash-image"
+DEFAULT="/usr/share/batocera/splash/logo-version.png"
+SPLASH_DIR=/userdata/splash
+
+FM_IMAGE=".*\.\(jpg\|jpeg\|png\)"
+
+do_filerandomize ()
+{
+    local array
+    [[ -d "$SPLASH_DIR" ]] || return 1
+    readarray -t array < <(find "$SPLASH_DIR" -regex "$1" -maxdepth 1 -type f)
+    if [[ ${#array[@]} -gt 0 ]]; then
+        echo "${array[$RANDOM % ${#array[@]}]}"
+    fi
+}
+
 do_start ()
 {
-    if [[ $(ls /boot/splash/*.{jpg,png}  2>/dev/null) ]]
+    # no image => for ogoa (or any other), logo-version-wxh.png
+    if ! test -e "$DEFAULT"
     then
-        image="$(ls /boot/splash/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.{jpg,png} | wc -l)+1))!d")"
-    else
-        image="/usr/share/batocera/splash/logo-version.png"
-	# no image => for ogoa (or any other), logo-version-wxh.png
-	if ! test -e "${image}"
-	then
-	    image="/usr/share/batocera/splash/logo-version-"$(batocera-resolution currentResolution)".png"
-	fi
+        DEFAULT="/usr/share/batocera/splash/logo-version-"$(batocera-resolution currentResolution)".png"
     fi
 
-    # on some sytems, fb0 is not immediatly loaded, so, keep a chance by waiting a bit
-    N=0
-    while ! test -e /dev/fb0 -o $N -gt 15
-    do
-        sleep 1
-        let N++
-    done
-    test -e /dev/fb0 && fbv -f -i "${image}"
-    sleep infinity
-    wait $!
+    image_file=$(do_filerandomize "$FM_IMAGE")
+
+    if [[ -n "$image_file" ]]; then
+        do_imagestart "$image_file"
+    else
+        do_imagestart "$DEFAULT"
+    fi
+}
+
+do_imagestart ()
+{
+    image="$1"
+    printf 'Image: %s: ' "$image"
+    if test -e /dev/fb0
+    then
+        start-stop-daemon -S -b -q -m -p /var/run/user-splash-image.pid --exec fbv -- -f -i "$image"
+    fi
 }
 
 case "$1" in
     start)
-        grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf" && exit 0
-        do_start &
+        printf 'Starting %s: ' "$DAEMON"
+        if grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf"
+        then
+            echo "SKIPPED"
+            exit 0
+        fi
+        do_start
+        echo "OK"
         ;;
     stop)
+        start-stop-daemon -K -q -p /var/run/user-splash.pid
         ;;
     restart|reload)
         ;;

--- a/package/batocera/core/batocera-splash/Ssplash-mpv.template
+++ b/package/batocera/core/batocera-splash/Ssplash-mpv.template
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-DAEMON="splash"
+DAEMON="splash-mpv"
+DEFAULT="/usr/share/batocera/splash/splash.mp4"
+SPLASH_DIR=/userdata/splash
+
+FM_IMAGE=".*\.\(jpg\|jpeg\|png\)"
+FM_VIDEO=".*\.\(mp4\|MP4\)"
 
 . /etc/profile.d/xdg.sh
 . /etc/profile.d/dbus.sh
 
-soundDisabled() {
+soundDisabled()
+{
     grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
 }
 
@@ -15,37 +21,44 @@ do_angels_conversion ()
     return $?
 }
 
-do_start ()
+do_filerandomize ()
 {
-    if ls /boot/splash/*.mp4 >/dev/null 2>/dev/null
-    then
-        do_videostart "$(ls /boot/splash/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.mp4 | wc -l)+1))!d")"
-    elif [[ $(ls /boot/splash/*.{jpg,png}  2>/dev/null) ]]
-    then
-        do_imagestart "$(ls /boot/splash/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.{jpg,png} | wc -l)+1))!d")"
+    local array
+    [[ -d "$SPLASH_DIR" ]] || return 1
+    readarray -t array < <(find "$SPLASH_DIR" -regex "$1" -maxdepth 1 -type f)
+    if [[ ${#array[@]} -gt 0 ]]; then
+        echo "${array[$RANDOM % ${#array[@]}]}"
+    fi
+}
+
+do_start()
+{
+    video_file=$(do_filerandomize "$FM_VIDEO")
+    image_file=$(do_filerandomize "$FM_IMAGE")
+
+    if [[ -n "$video_file" ]]; then
+        do_videostart "$video_file"
+    elif [[ -n "$image_file" ]]; then
+        do_imagestart "$image_file"
     else
-        do_videostart "/usr/share/batocera/splash/splash.mp4"
+        do_videostart "$DEFAULT"
     fi
 }
 
 do_imagestart()
 {
     image="$1"
-    # on some sytems, fb0 is not immediatly loaded, so, keep a chance by waiting a bit
-    N=0
-    while ! test -e /dev/fb0 -o $N -gt 15
-    do
-        sleep 1
-        let N++
-    done
-    test -e /dev/fb0 && fbv -f -i "${image}"
-    sleep infinity
-    wait $!
+    printf 'Image: %s: ' "$image"
+    if test -e /dev/fb0
+    then
+        start-stop-daemon -S -b -q -m -p /var/run/user-splash-image.pid --exec fbv -- -f -i "$image"
+    fi
 }
 
 do_videostart ()
 {
     video="$1"
+    printf 'Video: %s: ' "$video"
     mpv_audio=
     if soundDisabled
     then
@@ -60,18 +73,22 @@ do_videostart ()
     fi
 
     # it should be drm everywhere (including for x86_64 while it is on fb) -- only rpi doesn't use drm and it doesn't use this boot splash script
-    /usr/bin/mpv --really-quiet --no-config --hwdec=yes %PLAYER_OPTIONS% $mpv_audio $mpv_video "$video" &
-    wait $!
+    start-stop-daemon -S -b -q -m -p /var/run/user-splash.pid --exec /usr/bin/mpv -- --really-quiet --no-config --hwdec=yes %PLAYER_OPTIONS% $mpv_audio $mpv_video "$video"
 }
 
 case "$1" in
     start)
         printf 'Starting %s: ' "$DAEMON"
-        grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf" && exit 0
-        do_start &
+        if grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf"
+        then
+            echo "SKIPPED"
+            exit 0
+        fi
+        do_start
         echo "OK"
         ;;
     stop)
+        start-stop-daemon -K -q -p /var/run/user-splash.pid
         ;;
     restart|reload)
         ;;

--- a/package/batocera/core/batocera-splash/Ssplash-omx
+++ b/package/batocera/core/batocera-splash/Ssplash-omx
@@ -1,41 +1,64 @@
 #!/bin/bash
 
-soundDisabled() {
+DAEMON="splash-omx"
+DEFAULT="/usr/share/batocera/splash/splash.mp4"
+SPLASH_DIR=/userdata/splash
+
+FM_IMAGE=".*\.\(jpg\|jpeg\|png\)"
+FM_VIDEO=".*\.\(mp4\|MP4\)"
+
+. /etc/profile.d/xdg.sh
+. /etc/profile.d/dbus.sh
+
+soundDisabled()
+{
     grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
 }
 
-do_start ()
+do_angels_conversion ()
 {
-    if ls /boot/splash/*.mp4 >/dev/null 2>/dev/null
-    then
-        do_videostart "$(ls /boot/splash/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.mp4 | wc -l)+1))!d")"
-    elif [[ $(ls /boot/splash/*.{jpg,png}  2>/dev/null) ]]
-    then
-        do_imagestart "$(ls /boot/splash/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.{jpg,png} | wc -l)+1))!d")"
+    [[ $1 -lt 0 || $1 -gt 3 ]] && echo 0 || echo $(($1*90))
+    return $?
+}
+
+do_filerandomize ()
+{
+    local array
+    [[ -d "$SPLASH_DIR" ]] || return 1
+    readarray -t array < <(find "$SPLASH_DIR" -regex "$1" -maxdepth 1 -type f)
+    if [[ ${#array[@]} -gt 0 ]]; then
+        echo "${array[$RANDOM % ${#array[@]}]}"
+    fi
+}
+
+do_start()
+{
+    video_file=$(do_filerandomize "$FM_VIDEO")
+    image_file=$(do_filerandomize "$FM_IMAGE")
+
+    if [[ -n "$video_file" ]]; then
+        do_videostart "$video_file"
+    elif [[ -n "$image_file" ]]; then
+        do_imagestart "$image_file"
     else
-        do_videostart "/usr/share/batocera/splash/splash.mp4"
+        do_videostart "$DEFAULT"
     fi
 }
 
 do_imagestart()
 {
     image="$1"
-    # on some sytems, fb0 is not immediatly loaded, so, keep a chance by waiting a bit
-    N=0
-    while ! test -e /dev/fb0 -o $N -gt 15
-    do
-        sleep 1
-        let N++
-    done
-    test -e /dev/fb0 && fbv -f -i "${image}"
-    sleep infinity
-    wait $!
+    printf 'Image: %s: ' "$image"
+    if test -e /dev/fb0
+    then
+        start-stop-daemon -S -b -q -m -p /var/run/user-splash-image.pid --exec fbv -- -f -i "$image"
+    fi
 }
 
 do_videostart ()
 {
     video="$1"
-    # Launch the video
+    printf 'Video: %s: ' "$video"
     omx_fnt="--font=/usr/share/fonts/dejavu/DejaVuSans-BoldOblique.ttf"
     omx_opt="--no-keys --layer=10000 --aspect-mode=fill"
     omx_srt="--no-ghost-box --lines=1 --align=left $omx_fnt --font-size=20 --subtitles=/usr/share/batocera/splash/splash.srt"
@@ -46,17 +69,22 @@ do_videostart ()
         omx_nosound="-n -1"
     fi
 
-    /usr/bin/omxplayer -o both $omx_opt $omx_srt $omx_nosound "$video" &
-    wait $!    
+    start-stop-daemon -S -b -q -m -p /var/run/user-splash.pid --exec /usr/bin/omxplayer -- -o both $omx_opt $omx_srt $omx_nosound "$video"
 }
-
 
 case "$1" in
     start)
-        grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf" && exit 0
-        do_start &
+        printf 'Starting %s: ' "$DAEMON"
+        if grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf"
+        then
+            echo "SKIPPED"
+            exit 0
+        fi
+        do_start
+        echo "OK"
         ;;
     stop)
+        start-stop-daemon -K -q -p /var/run/user-splash.pid
         ;;
     restart|reload)
         ;;

--- a/package/batocera/core/batocera-splash/Ssplashscreencontrol
+++ b/package/batocera/core/batocera-splash/Ssplashscreencontrol
@@ -1,12 +1,11 @@
 #!/bin/sh
 # Splash Screen Control
 # This service controls length of video/picture displayed during startup
-# Furthermore it copies content from /userdata/splash to /boot/splash
 # by cyperghost aka lala on discord
 
 splash_autoplay ()
 {
-    count=0
+    local count=0
     while [ $count -lt 90 ]
     do
         sleep 1
@@ -19,7 +18,7 @@ splash_default_rpi ()
 {
     # Stop the video when ready
     # Wait for emulationstation or Kodi, but not more than 20 seconds
-    count=0
+    local count=0
     while [ ! -f "/tmp/emulationstation.ready" -a ! -e "/var/run/kodi.msg" -a $count -lt 20 ]
     do
         sleep 1
@@ -30,31 +29,28 @@ splash_default_rpi ()
 
 #### MAIN ####
 
-INIT_SERVICE=/etc/init.d/S28splash
-SPLASHBOOT=/boot/splash/
-SPLASHUSER=/userdata/splash/
 ARCH=$(cat /usr/share/batocera/batocera.arch)
 
 case $1 in
     start)
-	sleep 2 # let time to player to start and play the video (otherwise, it will not kill the video player is not yet started) ; Race condition between S28 and it's PPID, lazy hack
-
-        # Is service is active? PPID is videoplayer or pic sleep timer
-        PID=$(pgrep -P $(pgrep -f $INIT_SERVICE) 2>/dev/null ) || { echo "No service '$INIT_SERVICE' found!"; exit 0; }
-
-        # If the timer for picture is active then kill this PID to avoid
-        # unwanted behaviour in splash_autoplay
-        [ "$PID" = "$(pgrep -f "sleep infinity")" ] && picture=1 || picture=0
+        # Is service is active?
+        if [ -f "/var/run/user-splash-image.pid" ]; then
+            picture=1
+        elif [ -f "/var/run/user-splash.pid" ]; then
+            picture=0
+            PID=$(cat /var/run/user-splash.pid)
+        else
+            echo "$0: No video or image service found!" >&2
+            exit 0
+        fi
 
         # Read Config and set some defaults
         splash_setting="$(/usr/bin/batocera-settings-get splash.screen.length)"
-        [ -z $splash_setting ] && splash_setting=auto
-        [ $splash_setting = auto -a $(echo $ARCH | cut -c 1-3) = rpi ] && splash_setting=$ARCH
-
-        case $splash_setting in
+        [ -z "$splash_setting" ] && splash_setting=auto
+        [ "$splash_setting" = "auto" -a "$(echo $ARCH | cut -c 1-3)" = "rpi" ] && splash_setting=$ARCH
+        case "$splash_setting" in
             rpi1)
-                # Standard BATOCERA setting, for Pi platform
-                # A video splash will be displayed ~16s on Pi3 platform you'll smoothly boot into ES
+                # Standard BATOCERA setting, for Pi platform with OMX Player
                 #
                 splash_default_rpi &
             ;;
@@ -62,44 +58,25 @@ case $1 in
                 # Play video as long as possible, ideal for fast boards
                 #
                 [ $picture -eq 0 ] && splash_autoplay
-                kill -9 $PID 2>/dev/null
+                start-stop-daemon -K -q -p /var/run/user-splash.pid
             ;;
-            i[0-90]*|k[0-90]*|[0-90]*)
-                # k-mode: Stop loading process for x seconds, attention there will be no
-                #         further steps so you can "lock" the system
-                # i-mode: This mode will not kill video in background this is a posible setup
-                #         for RPi system and you will smoothly boot into ES
-                #
-                sleeptimer=$(echo $splash_setting | grep -Eo [0-9] | tr -d "\n")
+            [0-90]*)
+                # Stop as long as setted. 90s max for video, 10s max for images
+                sleeptimer=$(echo "$splash_setting" | grep -Eo [0-9] | tr -d "\n")
                 [ $picture -eq 1 -a $sleeptimer -gt 10 ] && sleeptimer=10
                 sleep $sleeptimer
-                [ $picture -eq 1 -o $(echo $splash_setting | cut -c 1) != i ] && kill -9 $PID 2>/dev/null
+                start-stop-daemon -K -q -p /var/run/user-splash.pid
             ;;
             fastboot|*)
                 # fastboot or invalid settings
                 #
-                kill -9 $PID 2>/dev/null
-                exit 0
+                start-stop-daemon -K -q -p /var/run/user-splash.pid
             ;;
         esac
     ;;
     stop)
-        #DryRun -n to test if there is a change in /userdata/splash/ if there is output then do sync job
-	# --modify-window=2 for different fs
-        RSYNC="rsync --modify-window=2 -tin --dirs --delete $SPLASHUSER $SPLASHBOOT"
-        #File changes can be detected by -i switch output
-        [ "$($RSYNC | grep -e '^\*deleting' -e '^>f++++++')" ] || exit 0
-
-        #Check filesize of /userdata/splash and set a directory size limit (512MB*1024kB)
-        [ "$(du -s $SPLASHUSER | awk '{print $1}')" -lt 524288 ] || exit 1
-
-        RSYNC="rsync --modify-window=2 -ti --dirs --delete $SPLASHUSER $SPLASHBOOT"
-        mount -o remount,rw /boot
-        $RSYNC | dialog --backtitle "batocera.linux" --progressbox "Syncing Splashscreen data..." 20 75 >/dev/tty1
-        mount -o remount,ro /boot
     ;;
     *)
         echo "Usage $0 {start|stop}"
-    ;;
 esac
 exit 0


### PR DESCRIPTION
add: deamon
add: extensible filemask for video and image files
removed: sync to /boot/splash
add: use /userdata/splash for user videos/images (limited by partition size now)
removed: loading in background mode (only aplayable for Pi1/0 now)